### PR TITLE
Make fn optional

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -127,7 +127,7 @@ type fetcherFn<Data> = ((...args: any) => Data | Promise<Data>) | null
 
 export default function useSWRNative<Data = any, Error = any>(
   key: keyInterface,
-  fn: fetcherFn<Data>,
+  fn?: fetcherFn<Data>,
   config?: ConfigInterface<Data, Error>
 ) {
   const swr = useSWR(key, fn, config)


### PR DESCRIPTION
I have a top-level `<SWRConfig/>` which specifies my fetcher function, so I only need to specify the key for `useSWRNative` to work. However, because `fn` is required here, Typescript still asks for the fetcher function. This request makes `fn` optional in light of SWRConfig.